### PR TITLE
Test direct PTX float4 loads

### DIFF
--- a/benchmarks/memory/test_benchmark.py
+++ b/benchmarks/memory/test_benchmark.py
@@ -99,6 +99,8 @@ def test_comprehensive_matrix_loading(verbose=True):
         10: "CUB block load",
         11: "CUB warp load",
         # Note: Texture memory (12) not included in this test
+        13: "PTX float4 ld.global",
+        14: "PTX float4 ld.global.nc",
     }
 
     results = {}


### PR DESCRIPTION
Add CUDA kernels for `float4` loading using direct PTX instructions (`ld.global.v4.f32` and `ld.global.nc.v4.f32`) to enable performance benchmarking.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-845de06e-3ccc-40b6-a7de-2ed0ffd6cb92) · [Cursor](https://cursor.com/background-agent?bcId=bc-845de06e-3ccc-40b6-a7de-2ed0ffd6cb92)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)